### PR TITLE
Fix sticky carry on LSR

### DIFF
--- a/CPU6502.js
+++ b/CPU6502.js
@@ -641,9 +641,9 @@ CPU6502.prototype._shift = function(dir, wrap, addr) {
     val = this.AC;
   }
 
+  this.SR &= (~this.SR_FLAGS.C) & 0xFF;
   if (dir.toLowerCase() === "left") {
     new_val = (val << 1) & 0xFF;
-    this.SR &= (~this.SR_FLAGS.C) & 0xFF;
     this.SR |= (val & 128) >> 7; //Get bit 7 (carry)
     if (wrap) new_val |= old_carry;
   } else if (dir.toLowerCase() === "right") {

--- a/disassembler.html
+++ b/disassembler.html
@@ -246,7 +246,8 @@
 			var coords = mirror.charCoords({ line: highlighted_line, ch: 0 }, "local");
 			
 			mirror.addLineClass(highlighted_line, "background", "highlighted");
-			mirror.scrollTo(0, coords.y - 30);
+            console.log(coords);
+			mirror.scrollTo(0, coords.top - 30);
 
 			var pc_field = document.getElementById("pc_field");
 			pc_field.value = "0x" + formatHex(a.cpu.PC);

--- a/disassembler.html
+++ b/disassembler.html
@@ -242,11 +242,9 @@
 			}
 
 			highlighted_line = a.cpu.PC - parseInt(document.getElementById("start_field").value, 16);
-            console.log(highlighted_line);
 			var coords = mirror.charCoords({ line: highlighted_line, ch: 0 }, "local");
 			
 			mirror.addLineClass(highlighted_line, "background", "highlighted");
-            console.log(coords);
 			mirror.scrollTo(0, coords.top - 30);
 
 			var pc_field = document.getElementById("pc_field");

--- a/test/test.js
+++ b/test/test.js
@@ -1306,7 +1306,7 @@ test("ASL", function() {
   deepEqual(appleToo.cpu.get_status_flags(), carry_neg_flag, "Carry and Negative flags should be set");
 });
 test("LSR", function() {
-  expect(4);
+  expect(6);
 
   appleToo.cpu.AC = 0xCD; // 0b11001101
 
@@ -1314,6 +1314,12 @@ test("LSR", function() {
 
   equal(appleToo.cpu.AC, 0x66, "Should shift AC right one bit");
   deepEqual(appleToo.cpu.get_status_flags(), carry_flag, "Carry flag should be set");
+
+  appleToo.cpu.AC = 0xCC; // 0b11001100
+  appleToo.cpu.shift("right");
+
+  equal(appleToo.cpu.AC, 0x66, "Should shift AC right one bit");
+  deepEqual(appleToo.cpu.get_status_flags(), unset_flags, "Carry flag should be clear");
 
   appleToo.cpu.SR = 0;
   appleToo.cpu.write_memory(0xABCD, 0xCD);


### PR DESCRIPTION
Shifting zero off the end of an LSR needs to clear carry, it was only setting it.