### PR TITLE
Fixes for keyboard and performance

### DIFF
--- a/disassembler.html
+++ b/disassembler.html
@@ -55,7 +55,7 @@
 			padding: 5px;
 		}
 		.data_table td {
-            font-family: menlo, consolas, monospace;
+			font-family: menlo, consolas, monospace;
 			padding: 3px;
 			border: 1px solid black;
 		}
@@ -84,27 +84,38 @@
 			appleScreen.width = a.char_w * 40;
 			appleScreen.height = a.char_h * 24;
 			document.onkeypress = function(e) {
-				console.log(e);
-				a.write_char_code(e.charCode + 128);
+				if (a.is_running() && e.charCode < 0x80) {
+					a.write_char_code(e.charCode + 128);
+					e.preventDefault();
+				}
 			};
 			document.onkeydown = function(e) {
-				var value = 0;
-				switch (e.keyCode) {
-					case 37:
-						value = 8;
-						break;
-					case 38:
-						value = 11;
-						break;
-					case 39:
-						value = 21;
-						break;
-					case 40:
-						value = 10;
-						break;
-				}
-				if (e.keyCode > 36 && e.keyCode < 41){
-					a.write_char_code(value + 128);
+				if (a.is_running()) {
+					var value = 0;
+					switch (e.keyCode) {
+						case 8:
+							value = 0x7f;
+							break;
+						case 27:
+							value = 27;
+							break;
+						case 37:
+							value = 8;
+							break;
+						case 38:
+							value = 11;
+							break;
+						case 39:
+							value = 21;
+							break;
+						case 40:
+							value = 10;
+							break;
+					}
+					if (value != 0){
+						a.write_char_code(value + 128);
+						e.preventDefault();
+					}
 				}
 			};
 
@@ -242,11 +253,10 @@
 			}
 
 			highlighted_line = a.cpu.PC - parseInt(document.getElementById("start_field").value, 16);
-            console.log(highlighted_line);
 			var coords = mirror.charCoords({ line: highlighted_line, ch: 0 }, "local");
 			
 			mirror.addLineClass(highlighted_line, "background", "highlighted");
-			mirror.scrollTo(0, coords.y - 30);
+			mirror.scrollTo(0, coords.top - 30);
 
 			var pc_field = document.getElementById("pc_field");
 			pc_field.value = "0x" + formatHex(a.cpu.PC);

--- a/index.html
+++ b/index.html
@@ -43,27 +43,39 @@
 			appleScreen.width = a.char_w * 40;
 			appleScreen.height = a.char_h * 24;
 			document.onkeypress = function(e) {
-				console.log(e);
-				a.write_char_code(e.charCode + 128);
+				if (a.is_running() && e.charCode < 0x80) {
+					a.write_char_code(e.charCode + 128);
+					console.log(e.charCode);
+					e.preventDefault();
+				}
 			};
 			document.onkeydown = function(e) {
-				var value = 0;
-				switch (e.keyCode) {
-					case 37:
-						value = 8;
-						break;
-					case 38:
-						value = 11;
-						break;
-					case 39:
-						value = 21;
-						break;
-					case 40:
-						value = 10;
-						break;
-				}
-				if (e.keyCode > 36 && e.keyCode < 41){
-					a.write_char_code(value + 128);
+				if (a.is_running()) {
+					var value = 0;
+					switch (e.keyCode) {
+						case 8:
+							value = 0x7f;
+							break;
+						case 27:
+							value = 27;
+							break;
+						case 37:
+							value = 8;
+							break;
+						case 38:
+							value = 11;
+							break;
+						case 39:
+							value = 21;
+							break;
+						case 40:
+							value = 10;
+							break;
+					}
+					if (value != 0){
+						a.write_char_code(value + 128);
+						e.preventDefault();
+					}
 				}
 			};
 


### PR DESCRIPTION
Keyboard fixes: add codes for backspace and escape. Only send
keys if running. Prevent default action when running. Retain
lower seven bits in KBD ($C000) when strobed ($C010).

Performance: preallocate hires graphics image buffer rather than
allocating once per row. Use copyWithin to duplicate rows rather
than repeatedly calling putImageData. These changes take draw()
from approx 30ms to approx 2ms.

Also fix scrolling coordinates on single-step.